### PR TITLE
Add utime(2) functions. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,3 +53,23 @@ plus offset bytes (usually negative or zero to seek to the end of the file).
 
 Synchronous lseek(2). Throws an exception on error.  Returns current
 file position.
+
+
+### fs.utime(path [, atime, mtime] [, callback])
+
+Asynchronous utime(2).
+
+Arguments `atime` and `mtime` are in seconds as for the system call.  Note
+that the number value of Date() is in milliseconds, so to use the 'now'
+value with `fs.utime()` you would have to divide by 1000 first, e.g. 
+Date.now()/1000
+
+Just like for utime(2), the absence of the `atime` and `mtime` means 'now'.
+
+### fs.utimeSync(path [, atime, mtime])
+
+Synchronous version of utime().  Throws an exception on error.
+
+
+
+

--- a/fs-ext.js
+++ b/fs-ext.js
@@ -59,13 +59,13 @@ exports.flock = function(fd, flags, callback) {
   var oper = stringToFlockFlags(flags);
 
   binding.flock(fd, oper, callback);
-}
+};
 
 exports.flockSync = function(fd, flags) {
   var oper = stringToFlockFlags(flags);
 
   return binding.flock(fd, oper);
-}
+};
 
 exports.seek = function(fd, position, whence, callback) {
   callback = arguments[arguments.length - 1];
@@ -74,11 +74,39 @@ exports.seek = function(fd, position, whence, callback) {
   }
 
   binding.seek(fd, position, whence, callback);
-}
+};
 
 exports.seekSync = function(fd, position, whence) {
   return binding.seek(fd, position, whence);
-}
+};
+
+
+// fs.utime('foo' [, atime, mtime] [, func] )
+
+exports.utime = function(path, atime, mtime, callback) {
+  callback = arguments[arguments.length - 1];
+  if (typeof(callback) !== 'function') {
+    callback = noop;
+  }
+
+  if (typeof(atime) !== 'number'  &&  typeof(mtime) !== 'number') {
+    atime = mtime = Date.now() / 1000;
+  }
+
+  binding.utime(path, atime, mtime, callback);
+};
+
+// fs.utimeSync('foo' [, atime, mtime] )
+
+exports.utimeSync = function(path, atime, mtime) {
+
+  if (typeof(atime) !== 'number'  &&  typeof(mtime) !== 'number') {
+    atime = mtime = Date.now() / 1000;
+  }
+
+  return binding.utime(path, atime, mtime);
+};
+
 
 // populate with fs functions from there
 for (var key in fs) {

--- a/run_tests
+++ b/run_tests
@@ -4,6 +4,8 @@ node tests/test-fs-seek.js
 
 node tests/test-fs-flock.js
 
+node tests/test-fs-utime.js
+
 # for stress testing only 
 # node tests/test-fs-seek_stress.js
 # node tests/test-fs-flock_stress.js

--- a/tests/test-fs-utime.js
+++ b/tests/test-fs-utime.js
@@ -1,0 +1,365 @@
+
+// Test these APIs as published in extension module 'fs-ext'
+//
+// fs.utime(path, 
+//
+// fs.utimeSync(path, 
+//
+// Synchronous utime(2). Throws an exception on error.
+
+// Ideas for testing borrowed from bnoordhuis (Ben Noordhuis)
+
+
+//TODO and Questions
+
+//XXX Is it 'standard' for async calls to die with exceptions on bad
+//  argument values, rather than calling the callback with the error?
+
+//XXX Why doesn't event callback receive exit code value?
+//  They do!  Just not documented!
+
+
+// Make this new-built copy of fs-ext available for testing
+require.paths.unshift(__dirname + '/..');
+//  console.log( require.resolve('../fs-ext'));
+
+var assert = require('assert'),
+    path   = require('path'),
+    util   = require('util'),
+    fs     = require('../fs-ext');
+
+var tests_ok = 0;
+var tests_run = 0;
+
+var debug_me = true;
+    debug_me = false;
+
+var tmp_dir = "/tmp",
+    file_path     = path.join(tmp_dir, 'what.when.utime.test'),
+    file_path_not = path.join(tmp_dir, 'what.not.utime.test');
+
+var file_fd,
+    result,
+    err;
+
+
+// Report on test results -  -  -  -  -  -  -  -  -  -  -  -
+
+// Clean up and report on final success or failure of tests here
+process.addListener('exit', function listen_for_exit(exit_code) {
+  //if (debug_me) console.log('    exit_code  %j', exit_code);
+
+  remove_file_wo_error(file_path);
+
+  console.log('Tests run: %d     ok: %d', tests_run, tests_ok);
+
+  if ( ! exit_code  &&  tests_ok !== tests_run ) {
+    console.log('One or more subtests failed!');
+    process.removeListener('exit', listen_for_exit);
+    process.exit(1);
+  }
+});
+
+
+// Test helpers -  -  -  -  -  -  -  -  -  -  -  -  -  -  -
+
+function remove_file_wo_error(file_path) {
+  // Delete any prior copy of test data file(s)
+  try {
+    fs.unlinkSync(file_path);
+  } catch (e) {
+    // might not exist, that's okay.
+  }
+  
+  try {
+    fs.unlinkSync(file_path_not);
+  } catch (e) {
+    // might not exist, that's okay.
+  }
+}
+
+
+function date2unixtime(date_val) {
+  return Math.floor( date_val / 1000 );
+}
+
+
+function expect_ok(api_name, resource, err) {
+  var fault_msg;
+
+  get_times_seen(resource);
+
+  if ( err ) {
+    if ( err instanceof Error ) {
+      fault_msg = api_name + '(): returned error ' + err.message;
+    } else {
+      fault_msg = api_name + '(): returned error ' + err;
+    }
+  } else if ( atime_seen == atime_old ) {
+    fault_msg = api_name + '(): atime was unchanged';
+  } else if ( mtime_seen == mtime_old ) {
+    fault_msg = api_name + '(): mtime was unchanged';
+  } else if ( atime_seen !== atime_req ) {
+    fault_msg = api_name + '(): atime not correct result';
+  } else if ( mtime_seen !== mtime_req ) {
+    fault_msg = api_name + '(): mtime not correct result';
+  }
+
+  if ( ! fault_msg ) {
+    tests_ok++;
+    if (debug_me) console.log('        OK: ' + api_name );
+  } else {
+    //XXX Create array from arguments adding xtime_req, xtime_seen to end?
+    console.log('FAILURE: ' + arguments.callee.name + ': ' + fault_msg);
+    //if (debug_me) console.log('   ARGS: ', util.inspect(arguments));
+  }
+}
+
+
+function expect_errno(api_name, err, value_seen, expected_errno) {
+  var fault_msg;
+
+  if (debug_me) console.log('  expected_errno(err): ' + err );
+
+  if ( err ) {
+    if ( err instanceof Error ) {
+      if ( err.code !== undefined ) {
+        if ( err.code !== expected_errno ) {
+            fault_msg = api_name + '(): returned wrong errno \'' + err.message +
+                                      '\'  (expecting ' + expected_errno + ')';
+          }
+      } else {
+        fault_msg = api_name + '(): returned wrong error \'' + err + '\'';
+      }
+    } else {
+      fault_msg = api_name + '(): returned wrong error \'' + err + '\'';
+    }
+  } else {
+    fault_msg = api_name + '(): expected errno \'' + expected_errno + 
+                                 '\', but got result ' + value_seen;
+  }
+
+  if ( ! fault_msg ) {
+    tests_ok++;
+    if (debug_me) console.log(' FAILED OK: ' + api_name );
+  } else {
+    console.log('FAILURE: ' + arguments.callee.name + ': ' + fault_msg);
+    //if (debug_me) console.log('   ARGS: ', util.inspect(arguments));
+  }
+}
+
+
+
+// Setup for testing    -  -  -  -  -  -  -  -  -  -  -  -
+
+
+// Check whether this version of node.js has these APIs to test
+//XXX Consider just exiting without error after displaying notices
+
+tests_run++;
+if ( typeof fs.utime !== 'function' ) {
+  console.log('fs.utime API is missing'); 
+} else {  
+  tests_ok++;
+}
+
+tests_run++;
+if ( typeof fs.utimeSync !== 'function' ) {
+  console.log('fs.utimeSync API is missing');
+} else {  
+  tests_ok++;
+}
+
+// If any pre-checks and setup fail, quit before tests
+if ( tests_run !== tests_ok ) {     
+  process.exit(2);
+}
+
+
+// Delete any prior copy of test data file(s)
+remove_file_wo_error(file_path);
+
+// Create a new file
+tests_run++;
+try {
+  var file_fd = fs.openSync(file_path, 'w');
+  fs.closeSync(file_fd);
+  tests_ok++;
+} catch (e) {
+  console.log('  Unable to create test data file %j', file_path);
+  console.log('    Error was: %j', e);
+}
+
+
+var atime_old,    mtime_old,
+    atime_req,    mtime_req,
+    atime_seen,   mtime_seen;
+
+function debug_show_times() {
+  console.log('  atime/mtime old   %d  %d', atime_old,   mtime_old  );
+  console.log('  atime/mtime reqd  %d  %d', atime_req,   mtime_req  );
+  console.log('  atime/mtime seen  %d  %d', atime_seen,  mtime_seen );
+}
+
+function debug_show_times_long() {
+//console.log('  atime old   %s', new Date( 1000 * atime_old));
+//console.log('  mtime old   %s', new Date( 1000 * mtime_old));
+  console.log('  atime reqd  %s', new Date( 1000 * atime_req));
+  console.log('  mtime reqd  %s', new Date( 1000 * mtime_req));
+  console.log('  atime seen  %s', new Date( 1000 * atime_seen));
+  console.log('  mtime seen  %s', new Date( 1000 * mtime_seen));
+  console.log('');
+}
+    
+function get_times_seen(path) {
+  var fs_stats = fs.statSync(path);
+  atime_seen = date2unixtime(fs_stats.atime);
+  mtime_seen = date2unixtime(fs_stats.mtime);
+}
+
+function setup_test_values( new_atime, new_mtime ) {
+  atime_old = atime_seen;
+  mtime_old = mtime_seen;
+  atime_req = new_atime;
+  mtime_req = new_mtime;
+}
+
+function check_results(test_path) {
+  get_times_seen(test_path);
+  console.log('  atime/mtime old   %d  %d', atime_old,   mtime_old  );
+  console.log('  atime/mtime reqd  %d  %d', atime_req,   mtime_req  );
+  console.log('  atime/mtime seen  %d  %d', atime_seen,  mtime_seen );
+  assert.notStrictEqual(atime_seen, atime_old, api_name + '(): atime was unchanged');
+  assert.notStrictEqual(mtime_seen, mtime_old, api_name + '(): mtime was unchanged');
+  assert.strictEqual(atime_seen, atime_req,    api_name + '(): atime not correct result');
+  assert.strictEqual(mtime_seen, mtime_req,    api_name + '(): mtime not correct result');
+}
+
+
+// Begin tests for utimeSync()
+//
+//    fs.utimeSync('foo' [, atime, mtime] )
+
+
+get_times_seen(file_path);
+
+if (debug_me) {
+  console.log('');
+  console.log('Time now is:  %s', new Date());
+  console.log('');
+  console.log('initial file times:');
+  console.log('  atime old   %s', new Date( 1000 * atime_seen));
+  console.log('  mtime old   %s', new Date( 1000 * mtime_seen));
+  console.log('');
+}
+
+
+// Use wrong filename to get 'ENOENT' error                   
+
+setup_test_values( 0, 0 );
+tests_run++;
+result = err = undefined;
+try {
+  result = fs.utimeSync(file_path_not, atime_req, mtime_req);
+} catch (e) {
+  err = e;
+}
+expect_errno('utimeSync', err, result, 'ENOENT');
+
+// Reset 'previous' times as unchanged by failed call
+atime_seen = mtime_seen = 0;
+
+
+// Set to 'now' by omitting time arguments
+setup_test_values( date2unixtime(new Date()), date2unixtime(new Date()));
+tests_run++;
+result = err = undefined;
+try {
+  result = fs.utimeSync(file_path);
+} catch (e) {
+  err = e;
+}
+expect_ok('utimeSync', file_path, err);
+if (debug_me) debug_show_times_long();
+
+
+
+// Set to specific constant seconds values
+
+setup_test_values( 1306707599, 1303922297 );
+tests_run++;
+result = err = undefined;
+try {
+  result = fs.utimeSync(file_path, atime_req, mtime_req);
+} catch (e) {
+  err = e;
+}
+expect_ok('utimeSync', file_path, err);
+if (debug_me) debug_show_times_long();
+
+
+// Set to specific values derived from Date()
+
+setup_test_values( date2unixtime(new Date('1999-01-01 01:01:00 UTC')),
+                   date2unixtime(new Date('1999-01-01 01:01:01 UTC')));
+
+tests_run++;
+result = err = undefined;
+try {
+  result = fs.utimeSync(file_path, atime_req, mtime_req);
+} catch (e) {
+  err = e;
+}
+expect_ok('utimeSync', file_path, err);
+if (debug_me) debug_show_times_long();
+
+
+// Try what would be special signal values
+
+setup_test_values( -1, -1 );
+tests_run++;
+result = err = undefined;
+try {
+  result = fs.utimeSync(file_path, atime_req, mtime_req);
+} catch (e) {
+  err = e;
+}
+expect_ok('utimeSync', file_path, err);
+if (debug_me) debug_show_times_long();
+
+
+
+// Begin tests for utime()
+
+// Set to a specific Date value
+setup_test_values( date2unixtime(new Date('1999-02-02 02:02:00 UTC')),
+                   date2unixtime(new Date('1999-02-02 02:02:01 UTC')));
+tests_run++;
+
+fs.utime(file_path, atime_req, mtime_req, function(err){
+  expect_ok('utime', file_path, err);
+  if (debug_me) debug_show_times_long();
+
+  // Set to 'now' 
+  setup_test_values( date2unixtime(new Date()), 
+                     date2unixtime(new Date()));
+  tests_run++;
+
+  fs.utime(file_path, atime_req, mtime_req, function(err){
+    expect_ok('utime', file_path, err);
+    if (debug_me) debug_show_times_long();
+
+    // Use wrong filename to get 'ENOENT' error                   
+    setup_test_values( date2unixtime(new Date('1999-01-01 01:01:00 UTC')),
+                       date2unixtime(new Date('1999-01-01 01:01:01 UTC')));
+    tests_run++;
+
+    fs.utime(file_path_not, atime_req, mtime_req, function(err){
+      expect_errno('utime', err, undefined, 'ENOENT');
+      if (debug_me) debug_show_times_long();
+      
+      // Reset 'previous' times as unchanged by failed call
+      atime_seen = mtime_seen = 0;
+    });
+  });
+});

--- a/tests/test-fs-utime_stress.js
+++ b/tests/test-fs-utime_stress.js
@@ -1,0 +1,292 @@
+
+// Stress test these APIs as published in extension module 'fs-ext'
+// Specifically, try to exercise any memory leaks by simple repetition.
+
+// Test these APIs as published in extension module 'fs-ext'
+//
+// fs.utime(path [, atime, mtime] [, func] )
+//
+// fs.utimeSync(path [, atime, mtime] )
+//
+// Synchronous utime(2). Throws an exception on error.
+
+
+// Ideas for testing borrowed from bnoordhuis (Ben Noordhuis)
+
+
+//TODO and Questions
+
+
+// Make this new-built copy of fs-ext available for testing
+require.paths.unshift(__dirname + '/..');
+//  console.log( require.resolve('../fs-ext'));
+
+var assert = require('assert'),
+    path   = require('path'),
+    util   = require('util'),
+    fs     = require('../fs-ext');
+
+var tests_ok = 0;
+var tests_run = 0;
+
+var debug_me = true;
+    debug_me = false;
+
+var tmp_dir = "/tmp",
+    file_path     = path.join(tmp_dir, 'what.when.utime.test'),
+    file_path_not = path.join(tmp_dir, 'what.not.utime.test');
+
+var result,
+    err;
+
+var atime_old,    mtime_old,
+    atime_req,    mtime_req,
+    atime_seen,   mtime_seen;
+
+
+
+// Report on test results -  -  -  -  -  -  -  -  -  -  -  -
+
+// Clean up and report on final success or failure of tests here
+process.addListener('exit', function listen_for_exit(exit_code) {
+  //if (debug_me) console.log('    exit_code  %j', exit_code);
+
+  console.log('');
+  console.log('  After all testing:');
+  display_memory_usage_now();
+  console.log('    End time is %s', new Date());
+
+  remove_file_wo_error(file_path);
+
+  console.log('Tests run: %d     ok: %d', tests_run, tests_ok);
+
+  if ( ! exit_code  &&  tests_ok !== tests_run ) {
+    console.log('One or more subtests failed!');
+    process.removeListener('exit', listen_for_exit);
+    process.exit(1);
+  }
+});
+
+
+// Test helpers -  -  -  -  -  -  -  -  -  -  -  -  -  -  -
+
+function remove_file_wo_error(file_path) {
+  try {
+    fs.unlinkSync(file_path);
+  } catch (e) {
+    // might not exist, that's okay.
+  }
+}
+
+
+function date2unixtime(date_val) {
+  return Math.floor( date_val / 1000 );
+}
+
+
+function display_memory_usage_now() {
+  var usage = process.memoryUsage();
+  console.log('    memory:  heapUsed  %d      rss       %d', 
+                                usage.heapUsed,  usage.rss);
+  console.log('             heapTotal %d      vsize     %d', 
+                                usage.heapTotal, usage.vsize);
+}
+
+
+function expect_value(api_name, err, value_seen, value_expected) {
+  var fault_msg;
+
+  if ( err ) {
+    if ( err instanceof Error ) {
+      fault_msg = api_name + '(): returned error ' + err.message;
+    } else {
+      fault_msg = api_name + '(): returned error ' + err;
+    }
+  } else {
+    if ( value_seen !== value_expected ) {
+      fault_msg = api_name + '(): wrong value ' + value_seen +
+                                   '  (expecting ' + value_expected + ')';
+    }
+  }
+
+  if ( ! fault_msg ) {
+    tests_ok++;
+    if (debug_me) console.log('        OK: %s() returned ', api_name, value_seen);
+  } else {
+    console.log('FAILURE: ' + arguments.callee.name + ': ' + fault_msg);
+    console.log('   ARGS: ', util.inspect(arguments));
+  }
+}
+
+
+function expect_errno(api_name, err, value_seen, expected_errno) {
+  var fault_msg;
+
+  if (debug_me) console.log('  expected_errno(err): ' + err );
+
+  if ( err ) {
+    if ( err instanceof Error ) {
+      if ( err.code !== undefined ) {
+        if ( err.code !== expected_errno ) {
+            fault_msg = api_name + '(): returned wrong errno \'' + err.message +
+                                      '\'  (expecting ' + expected_errno + ')';
+          }
+      } else {
+        fault_msg = api_name + '(): returned wrong error \'' + err + '\'';
+      }
+    } else {
+      fault_msg = api_name + '(): returned wrong error \'' + err + '\'';
+    }
+  } else {
+    fault_msg = api_name + '(): expected errno \'' + expected_errno + 
+                                 '\', but got result ' + value_seen;
+  }
+
+  if ( ! fault_msg ) {
+    tests_ok++;
+    if (debug_me) console.log(' FAILED OK: ' + api_name );
+  } else {
+    console.log('FAILURE: ' + arguments.callee.name + ': ' + fault_msg);
+    if (debug_me) console.log('   ARGS: ', util.inspect(arguments));
+  }
+}
+
+
+// Setup for testing    -  -  -  -  -  -  -  -  -  -  -  -
+
+// We assume that test-fs-utime.js has run successfully before this 
+// test and so we omit several duplicate tests.
+
+// Delete any prior copy of test data file(s)
+remove_file_wo_error(file_path);
+
+// Create a new file
+tests_run++;
+try {
+  var file_fd = fs.openSync(file_path, 'w');
+  fs.closeSync(file_fd);
+  tests_ok++;
+} catch (e) {
+  console.log('  Unable to create test data file %j', file_path);
+  console.log('    Error was: %j', e);
+}
+
+
+if ( tests_run !== tests_ok ) {     
+  process.exit(1);
+}
+
+
+// Stress testing    -  -  -  -  -  -  -  -  -  -  -  -  -
+
+var how_many_times,
+    how_many_secs,
+    how_many_done;
+
+
+console.log('  Start time is %s', new Date());
+console.log('  Before any testing:');
+display_memory_usage_now();
+console.log('');
+
+atime_req = mtime_req = date2unixtime(new Date());
+
+// Repeat a successful utimeSync() call 
+if( 1 ) {
+  how_many_times = 1000000;
+  //how_many_times = 4;
+
+  for( var i=0 ; i<how_many_times ; i++ ) {
+    tests_run++;
+    result = err = undefined;
+    result = fs.utimeSync(file_path, atime_req, mtime_req);
+    expect_value('utimeSync', err, result, undefined);
+  }
+
+  console.log('  After %d calls to successful utimeSync():', how_many_times);
+  display_memory_usage_now();
+  console.log('        Time is %s', new Date());
+}
+
+
+// Repeat an failing utimeSync() call 
+if( 1 ) {
+  how_many_times = 1000000;
+  //how_many_times = 4;
+
+  for( var i=0 ; i<how_many_times ; i++ ) {
+    tests_run++;
+    result = err = undefined;
+    try {
+      result = fs.utimeSync(file_path_not, atime_req, mtime_req);
+    } catch (e) {
+      err = e;
+    }
+    expect_errno('utimeSync', err, result, 'ENOENT');
+////tests_ok++;
+  }
+
+  console.log('  After %d calls to failing utimeSync():', how_many_times);
+  display_memory_usage_now();
+  console.log('        Time is %s', new Date());
+}
+
+
+
+// Repeat a successful utime() call 
+if (1) {
+  how_many_times = 1000000;
+  //how_many_times = 4;
+  how_many_done  = 0;
+ 
+  tests_run++;
+  fs.utime(file_path, 0, 0, function func_good_utime_cb(err, result){
+    expect_value('utime', err, result, undefined);
+    if (debug_me) console.log('    utime call counter   %d', how_many_times );
+
+    how_many_done += 1;
+    if ( how_many_done < how_many_times ) {
+      tests_run++;
+      fs.utime(file_path, 0, 0, func_good_utime_cb );
+      return;
+    }
+    console.log('  After %d calls to successful utime():', how_many_times);
+    display_memory_usage_now();
+    console.log('        Time is %s', new Date());
+
+    test_failing_utime();
+  });
+} else {
+  test_failing_utime();
+}  
+
+
+function test_failing_utime() {
+
+  if (1) {
+    how_many_times = 1000000;
+    //how_many_times = 4;
+    how_many_done  = 0;
+ 
+    tests_run++;
+    fs.utime(file_path_not, 0, 0, function func_good_utime_cb(err, result){
+      expect_errno('utime', err, result, 'ENOENT');
+      if (debug_me) console.log('    utime call counter   %d', how_many_times );
+
+      how_many_done += 1;
+      if ( how_many_done < how_many_times ) {
+        tests_run++;
+        fs.utime(file_path_not, 0, 0, func_good_utime_cb );
+        return;
+      }
+      console.log('  After %d calls to failing utime():', how_many_times);
+      display_memory_usage_now();
+      console.log('        Time is %s', new Date());
+    });
+  }
+
+}
+
+
+
+


### PR DESCRIPTION
The attempt to include fs.utimes() into node finds that utimes() is explicitly
not supported by Windows. utime() is better supported. Add that here.

Finally got around to doing the stress test to finish up.  Haven't yet rebuilt under Windows so there might be some gotchas there.

Forgive me - I succumbed to JSlint complaining about the missing semicolons at the end of

```
    foo = function (zowie) { pow; biff; kablammo; }
```
