### PR TITLE
win32: Replace LOCK_* constants with macros

### DIFF
--- a/fs-ext.cc
+++ b/fs-ext.cc
@@ -74,10 +74,10 @@ static Persistent<String> f_ffree_symbol;
 #endif
 
 #ifdef _WIN32
-  const int LOCK_SH=1;
-  const int LOCK_EX=2;
-  const int LOCK_NB=4;
-  const int LOCK_UN=8;
+  #define LOCK_SH 1
+  #define LOCK_EX 2
+  #define LOCK_NB 4
+  #define LOCK_UN 8
 #endif
 
 enum


### PR DESCRIPTION
Change LOCK_\* from constants to preprocessor macros, because that's what
the code exporting them to javascript expects.

This is a partial fix for #30. 

/to @baudehlo
/cc @winnetou1357
