### PR TITLE
Add support for file locking via fcntl. Flock doesn't work well with NFS...

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,9 +66,10 @@ and also F_RDLCK, F_WRLCK and F_UNLCK for use with F_SETLK (etc).
 
 File locking can be used like so:
 
-	fs.fcntl(fd, 'setlkw', constants.F_WRLCK, function(err, result)
-	{ 
-		
+	fs.fcntl(fd, 'setlkw', constants.F_WRLCK, function(err, result) { 
+		if (result!=null) {
+			//Lock succeeded
+		}
 	});
 
 ### fs.fcntlSync(fd, flags)

--- a/README.md
+++ b/README.md
@@ -52,8 +52,19 @@ The supported commands are:
 
 - 'getfd' ( F_GETFD )
 - 'setfd' ( F_SETFD )
+- 'setlk' ( F_SETLK )
+- 'getlk' ( F_GETLK )
+- 'setlkw' ( F_SETLKW )
 
-Requiring this module adds `FD_CLOEXEC` to the constants module, for use with F_SETFD.
+Requiring this module adds `FD_CLOEXEC` to the constants module, for use with F_SETFD,
+and also F_RDLCK, F_WRLCK and F_UNLCK for use with F_SETLK (etc).
+
+File locking can be used like so:
+
+	fs.fcntl(fd, 'setlkw', constants.F_WRLCK, function(err, result)
+	{ 
+		
+	});
 
 ### fs.fcntlSync(fd, flags)
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,11 @@ Asynchronous flock(2). No arguments other than a possible error are passed to
 the callback. Flags can be 'sh', 'ex', 'shnb', 'exnb', 'un' and correspond
 to the various LOCK_SH, LOCK_EX, LOCK_SH|LOCK_NB, etc.
 
+NOTE (from flock() man page): flock() does not lock files over NFS. Use fcntl(2)
+instead: that does work over NFS, given a sufficiently recent version of Linux
+and a server which supports locking.
+
+
 ### fs.flockSync(fd, flags)
 
 Synchronous flock(2). Throws an exception on error.

--- a/fs-ext.cc
+++ b/fs-ext.cc
@@ -206,14 +206,12 @@ static void EIO_Fcntl(uv_work_t *req) {
 		lk.l_whence = SEEK_SET;
 		lk.l_type   = data->arg;
 	}
-	result = fcntl(data->fd, data->oper, &lk);
+	data->result = result = fcntl(data->fd, data->oper, &lk); 
   } else {
-  	result = fcntl(data->fd, data->oper, data->arg);
+  	data->result = result = fcntl(data->fd, data->oper, data->arg);
   }
   if (result == -1) {
    	data->error = errno;
-  } else {
-	data->result = result;  
   }
 }
 

--- a/fs-ext.cc
+++ b/fs-ext.cc
@@ -581,6 +581,10 @@ init (Handle<Object> target)
   NODE_DEFINE_CONSTANT(target, F_WRLCK);
 #endif
 
+#ifdef F_UNLCK
+  NODE_DEFINE_CONSTANT(target, F_UNLCK);
+#endif
+
 #ifdef F_SETLK
   NODE_DEFINE_CONSTANT(target, F_SETLK);
 #endif

--- a/fs-ext.js
+++ b/fs-ext.js
@@ -61,13 +61,13 @@ function stringToFcntlFlags(flag) {
     case 'setfd':
       return binding.F_SETFD;
 
-    case 'setlk'
+    case 'setlk':
       return binding.F_SETLK;
 
-    case 'setlkw'
+    case 'setlkw':
       return binding.F_SETLKW;
 
-    case 'getlk'
+    case 'getlk':
       return binding.F_GETLK;
 
     default:

--- a/fs-ext.js
+++ b/fs-ext.js
@@ -30,19 +30,19 @@ function stringToFlockFlags(flag) {
   switch (flag) {
     case 'sh':
       return binding.LOCK_SH;
-    
+
     case 'ex':
       return binding.LOCK_EX;
-    
+
     case 'shnb':
       return binding.LOCK_SH | binding.LOCK_NB;
-    
+
     case 'exnb':
       return binding.LOCK_EX | binding.LOCK_NB;
-    
+
     case 'un':
       return binding.LOCK_UN;
-    
+
     default:
       throw new Error('Unknown flock flag: ' + flag);
   }
@@ -57,10 +57,19 @@ function stringToFcntlFlags(flag) {
   switch (flag) {
     case 'getfd':
       return binding.F_GETFD;
-    
+
     case 'setfd':
       return binding.F_SETFD;
-    
+
+    case 'setlk'
+      return binding.F_SETLK;
+
+    case 'setlkw'
+      return binding.F_SETLKW;
+
+    case 'getlk'
+      return binding.F_GETLK;
+
     default:
       throw new Error('Unknown fcntl flag: ' + flag);
   }


### PR DESCRIPTION
Self explanatory, really :)

We wanted to lock files via NFS, and unfortunately flock() doesn't do this correctly.

This adds support for file locking functionality via fcntl.
