### PR TITLE
Update nan for io.js 2.x.x compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "engines": {
     "node": ">= v0.8.0"
   },
-  "dependencies": { "nan": "~1.6" },
+  "dependencies": { "nan": "~1.8" },
   "licenses": [ {
     "type": "MIT"
   } ],


### PR DESCRIPTION
Referencing iojs/io.js#1620

Note: this PR does not address the usage of deprecated nan features causing compiler warnings. This just allows installation and compilation with io.js v2.x.x