### PR TITLE
Update nan dependency to work with io.js v2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "engines": {
     "node": ">= v0.8.0"
   },
-  "dependencies": { "nan": "~1.6" },
+  "dependencies": { "nan": "~1.8" },
   "licenses": [ {
     "type": "MIT"
   } ],


### PR DESCRIPTION
With older versions of nan, fs-ext won't build on io.js v2.0. The latest nan release still supports node v0.8, so this shouldn't break backwards compatibility. Tests pass on io.js v2.0.1 on my mac.

It would probably be a good idea to tag a new release after merging this.