### PR TITLE
Minimal patch to prevent breakage on node@11

### DIFF
--- a/fs-ext.js
+++ b/fs-ext.js
@@ -137,9 +137,11 @@ for (key in fs) {
 }
 
 // put constants into constants module (don't like doing this but...)
-for (key in binding) {
-  if (/^[A-Z_]+$/.test(key) && !constants.hasOwnProperty(key)) {
-    constants[key] = binding[key];
+if (!Object.isExtensible || Object.isExtensible(constants)) {
+  for (key in binding) {
+    if (/^[A-Z_]+$/.test(key) && !constants.hasOwnProperty(key)) {
+      constants[key] = binding[key];
+    }
   }
 }
 


### PR DESCRIPTION
Issue #76 explains that constants is not extensible in recent builds of node@11.

This changes the loop that adds constants from the C++ code to constants to be best effort.