### PR TITLE
Run tests against stable version of Node.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ node_js:
     - "6"
     - "8"
     - "10"
+    - "node"
 script:
     - npm run lint
     - npm test


### PR DESCRIPTION
Node@11 became stable per https://github.com/nodejs/Release#release-schedule
This changes .travis.yml to run against the current stable version of node in addition to even major versions.

I've used "stable" but apparently that is an undocumented alias for "node".

[Travis docs](https://docs.travis-ci.com/user/languages/javascript-with-nodejs/#specifying-nodejs-versions) say

> ## Specifying Node.js versions
> The easiest way to specify Node.js versions is to use one or more of the latest releases in your `.travis.yml`:
>
> * `node` latest stable Node.js release
> * ...