### PR TITLE
fix version inconsistency, now v1.3.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "fs-ext",
-  "version": "1.2.2",
+  "version": "1.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "flock",
     "seek"
   ],
-  "version": "1.3.0",
+  "version": "1.3.1",
   "homepage": "https://github.com/baudehlo/node-fs-ext/",
   "repository": {
     "type": "git",


### PR DESCRIPTION
The previous change updated the version in package-lock.json, but not package.json.  This updates package.json for a new release and gets the version package-lock.json in sync.