### PR TITLE
Don't override fs module, export constants as object

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,9 @@ Installation
 
 Install via npm:
 
-    npm install fs-ext
+```sh
+npm install fs-ext
+```
 
 Usage
 -----
@@ -24,14 +26,16 @@ fs-ext imports all of the methods from the core 'fs' module, so you don't
 need two objects.
 
 ```js
-var fs = require('fs-ext');
-var fd = fs.openSync('foo.txt', 'r');
-fs.flock(fd, 'ex', function (err) {
+const fs = require('fs');
+const {flock} = require('fs-ext');
+
+const fd = fs.openSync('foo.txt', 'r');
+flock(fd, 'ex', (err) => {
     if (err) {
-        return console.log("Couldn't lock file");
+        return console.error("Couldn't lock file");
     }
     // file is locked
-})
+});
 ```
 
 For an advanced example checkout `example.js`.
@@ -39,7 +43,7 @@ For an advanced example checkout `example.js`.
 API
 ---
 
-### fs.flock(fd, flags, [callback])
+### flock(fd, flags, [callback])
 
 Asynchronous flock(2). No arguments other than a possible error are passed to
 the callback. Flags can be 'sh', 'ex', 'shnb', 'exnb', 'un' and correspond
@@ -50,11 +54,11 @@ instead: that does work over NFS, given a sufficiently recent version of Linux
 and a server which supports locking.
 
 
-### fs.flockSync(fd, flags)
+### flockSync(fd, flags)
 
 Synchronous flock(2). Throws an exception on error.
 
-### fs.fcntl(fd, cmd, [arg], [callback])
+### fcntl(fd, cmd, [arg], [callback])
 
 Asynchronous fcntl(2).
 
@@ -74,29 +78,31 @@ and also F_RDLCK, F_WRLCK and F_UNLCK for use with F_SETLK (etc).
 File locking can be used like so:
 
 ```js
-fs.fcntl(fd, 'setlkw', constants.F_WRLCK, function (err, result) {
-    if (result != null) {
-        //Lock succeeded
+const {fnctl, constants} = require('fs-ext');
+
+fcntl(fd, 'setlkw', constants.F_WRLCK, (err) => {
+    if (!err) {
+        // Lock succeeded
     }
 });
 ```
 
-### fs.fcntlSync(fd, flags)
+### fcntlSync(fd, flags)
 
 Synchronous fcntl(2). Throws an exception on error.
 
-### fs.seek(fd, offset, whence, [callback])
+### seek(fd, offset, whence, [callback])
 
-Asynchronous lseek(2).  
+Asynchronous lseek(2).
 
 callback will be given two arguments (err, currFilePos).
 
-whence can be 0 (SEEK_SET) to set the new position in bytes to offset, 
-1 (SEEK_CUR) to set the new position to the current position plus offset 
-bytes (can be negative), or 2 (SEEK_END) to set to the end of the file 
+whence can be 0 (SEEK_SET) to set the new position in bytes to offset,
+1 (SEEK_CUR) to set the new position to the current position plus offset
+bytes (can be negative), or 2 (SEEK_END) to set to the end of the file
 plus offset bytes (usually negative or zero to seek to the end of the file).
 
-### fs.seekSync(fd, offset, whence)
+### seekSync(fd, offset, whence)
 
 Synchronous lseek(2). Throws an exception on error.  Returns current
 file position.

--- a/README.md
+++ b/README.md
@@ -7,8 +7,21 @@ fs-ext
 
 Extras not included in Node's fs module.
 
-**Note**: From v1.0.0 onwards, fs.utime and fs.utimeSync have been removed.
-Use fs.utimes and fs.utimesSync instead.
+**Note**:
+
+* From `v2.0.0` onwards, module doesn't override `fs` and `constants` Node.js core modules. Instead
+  import functions and constants directly:
+
+  ```js
+  const {flock, constants} = require('fs-ext');
+  // or
+  const fsExt = require('fs-ext');
+  // fsExt.flock
+  // fsExt.constants
+  ```
+
+* From `v1.0.0` onwards, fs.utime and fs.utimeSync have been removed.
+  Use fs.utimes and fs.utimesSync instead.
 
 Installation
 ------------

--- a/example.js
+++ b/example.js
@@ -1,6 +1,7 @@
 "use strict";
 
-var fs = require('./');
+var fs = require('fs');
+var {flock} = require('./');
 
 /**
  * Function that locks the current file
@@ -17,7 +18,7 @@ function getCurrentFileSize(counter, timeout, cb) {
 
   console.log("Trying to aquire lock for the %s time", counter);
 
-  fs.flock(fd, 'exnb', function(err) {
+  flock(fd, 'exnb', function(err) {
     if (err) {
       return console.log("Couldn't lock file", counter);
     }
@@ -26,7 +27,7 @@ function getCurrentFileSize(counter, timeout, cb) {
 
     // unlock after `timeout`
     setTimeout(function() {
-      fs.flock(fd, 'un', function(err) {
+      flock(fd, 'un', function(err) {
         if (err) {
           return console.log("Couldn't unlock file", counter);
         }

--- a/fs-ext.cc
+++ b/fs-ext.cc
@@ -240,21 +240,21 @@ static void EIO_Seek(uv_work_t *req) {
 #ifndef _WIN32
 static void EIO_Fcntl(uv_work_t *req) {
   store_data_t* data = static_cast<store_data_t *>(req->data);
-  
+
   struct flock lk;
   lk.l_start = 0;
   lk.l_len = 0;
   lk.l_type = 0;
   lk.l_whence = 0;
   lk.l_pid = 0;
-  
+
   int result = -1;
   if (data->oper == F_GETLK || data->oper == F_SETLK || data->oper == F_SETLKW) {
 	if (data->oper == F_SETLK || data->oper == F_SETLKW) {
 		lk.l_whence = SEEK_SET;
 		lk.l_type   = data->arg;
 	}
-	data->result = result = fcntl(data->fd, data->oper, &lk); 
+	data->result = result = fcntl(data->fd, data->oper, &lk);
   } else {
   	data->result = result = fcntl(data->fd, data->oper, data->arg);
   }
@@ -316,7 +316,7 @@ static int _win32_flock(int fd, int oper) {
       return -1;
   }
   if (i == -1) {
-    if (GetLastError() == ERROR_LOCK_VIOLATION) 
+    if (GetLastError() == ERROR_LOCK_VIOLATION)
       errno = EWOULDBLOCK;
     else
       errno = EINVAL;
@@ -525,69 +525,74 @@ NAN_MODULE_INIT(init)
   _set_invalid_parameter_handler(uv__crt_invalid_parameter_handler);
 #endif
 
+  v8::Local<v8::Object> constants = Nan::New<v8::Object>();
+
 #ifdef SEEK_SET
-  NODE_DEFINE_CONSTANT(target, SEEK_SET);
+  NODE_DEFINE_CONSTANT(constants, SEEK_SET);
 #endif
 
 #ifdef SEEK_CUR
-  NODE_DEFINE_CONSTANT(target, SEEK_CUR);
+  NODE_DEFINE_CONSTANT(constants, SEEK_CUR);
 #endif
 
 #ifdef SEEK_END
-  NODE_DEFINE_CONSTANT(target, SEEK_END);
+  NODE_DEFINE_CONSTANT(constants, SEEK_END);
 #endif
 
 #ifdef LOCK_SH
-  NODE_DEFINE_CONSTANT(target, LOCK_SH);
+  NODE_DEFINE_CONSTANT(constants, LOCK_SH);
 #endif
 
 #ifdef LOCK_EX
-  NODE_DEFINE_CONSTANT(target, LOCK_EX);
+  NODE_DEFINE_CONSTANT(constants, LOCK_EX);
 #endif
 
 #ifdef LOCK_NB
-  NODE_DEFINE_CONSTANT(target, LOCK_NB);
+  NODE_DEFINE_CONSTANT(constants, LOCK_NB);
 #endif
 
 #ifdef LOCK_UN
-  NODE_DEFINE_CONSTANT(target, LOCK_UN);
+  NODE_DEFINE_CONSTANT(constants, LOCK_UN);
 #endif
 
 #ifdef F_GETFD
-  NODE_DEFINE_CONSTANT(target, F_GETFD);
+  NODE_DEFINE_CONSTANT(constants, F_GETFD);
 #endif
 
 #ifdef F_SETFD
-  NODE_DEFINE_CONSTANT(target, F_SETFD);
+  NODE_DEFINE_CONSTANT(constants, F_SETFD);
 #endif
 
 #ifdef FD_CLOEXEC
-  NODE_DEFINE_CONSTANT(target, FD_CLOEXEC);
+  NODE_DEFINE_CONSTANT(constants, FD_CLOEXEC);
 #endif
 
 #ifdef F_RDLCK
-  NODE_DEFINE_CONSTANT(target, F_RDLCK);
+  NODE_DEFINE_CONSTANT(constants, F_RDLCK);
 #endif
 
 #ifdef F_WRLCK
-  NODE_DEFINE_CONSTANT(target, F_WRLCK);
+  NODE_DEFINE_CONSTANT(constants, F_WRLCK);
 #endif
 
 #ifdef F_UNLCK
-  NODE_DEFINE_CONSTANT(target, F_UNLCK);
+  NODE_DEFINE_CONSTANT(constants, F_UNLCK);
 #endif
 
 #ifdef F_SETLK
-  NODE_DEFINE_CONSTANT(target, F_SETLK);
+  NODE_DEFINE_CONSTANT(constants, F_SETLK);
 #endif
 
 #ifdef F_GETLK
-  NODE_DEFINE_CONSTANT(target, F_GETLK);
+  NODE_DEFINE_CONSTANT(constants, F_GETLK);
 #endif
 
 #ifdef F_SETLKW
-  NODE_DEFINE_CONSTANT(target, F_SETLKW);
+  NODE_DEFINE_CONSTANT(constants, F_SETLKW);
 #endif
+
+  Nan::Set(target, Nan::New("constants").ToLocalChecked(), constants);
+
   Export(target, "seek", Seek);
 #ifndef _WIN32
   Export(target, "fcntl", Fcntl);

--- a/fs-ext.js
+++ b/fs-ext.js
@@ -20,8 +20,6 @@
 "use strict";
 
 var binding = require('./build/Release/fs-ext');
-var fs = require('fs');
-var constants = require('constants');
 
 // Used by flock
 function stringToFlockFlags(flag) {
@@ -31,19 +29,19 @@ function stringToFlockFlags(flag) {
   }
   switch (flag) {
     case 'sh':
-      return binding.LOCK_SH;
+      return binding.constants.LOCK_SH;
 
     case 'ex':
-      return binding.LOCK_EX;
+      return binding.constants.LOCK_EX;
 
     case 'shnb':
-      return binding.LOCK_SH | binding.LOCK_NB;
+      return binding.constants.LOCK_SH | binding.constants.LOCK_NB;
 
     case 'exnb':
-      return binding.LOCK_EX | binding.LOCK_NB;
+      return binding.constants.LOCK_EX | binding.constants.LOCK_NB;
 
     case 'un':
-      return binding.LOCK_UN;
+      return binding.constants.LOCK_UN;
 
     default:
       throw new Error('Unknown flock flag: ' + flag);
@@ -58,19 +56,19 @@ function stringToFcntlFlags(flag) {
 
   switch (flag) {
     case 'getfd':
-      return binding.F_GETFD;
+      return binding.constants.F_GETFD;
 
     case 'setfd':
-      return binding.F_SETFD;
+      return binding.constants.F_SETFD;
 
     case 'setlk':
-      return binding.F_SETLK;
+      return binding.constants.F_SETLK;
 
     case 'setlkw':
-      return binding.F_SETLKW;
+      return binding.constants.F_SETLKW;
 
     case 'getlk':
-      return binding.F_GETLK;
+      return binding.constants.F_GETLK;
 
     default:
       throw new Error('Unknown fcntl flag: ' + flag);
@@ -130,18 +128,4 @@ exports.statVFS = function(path, callback) {
   return binding.statVFS(path, callback);
 };
 
-// populate with fs functions from there
-var key;
-for (key in fs) {
-  exports[key] = fs[key];
-}
-
-// put constants into constants module (don't like doing this but...)
-if (!Object.isExtensible || Object.isExtensible(constants)) {
-  for (key in binding) {
-    if (/^[A-Z_]+$/.test(key) && !constants.hasOwnProperty(key)) {
-      constants[key] = binding[key];
-    }
-  }
-}
-
+exports.constants = binding.constants;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "fs-ext",
-  "version": "1.2.2",
+  "version": "1.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "flock",
     "seek"
   ],
-  "version": "1.3.0",
+  "version": "2.0.0",
   "homepage": "https://github.com/baudehlo/node-fs-ext/",
   "repository": {
     "type": "git",

--- a/tests/test-fs-fcntl.js
+++ b/tests/test-fs-fcntl.js
@@ -2,14 +2,15 @@
 
 // Test these APIs as published in extension module 'fs-ext'
 //
-// fs.fcntl(fd, cmd, [arg], [callback])
+// fsExt.fcntl(fd, cmd, [arg], [callback])
 //
 //  console.log( require.resolve('../fs-ext'));
 
 var assert = require('assert'),
   path   = require('path'),
   util   = require('util'),
-  fs     = require('../fs-ext'),
+  fs     = require('fs'),
+  fsExt  = require('../fs-ext'),
   os     = require('os');
 
 var tests_ok  = 0,
@@ -100,16 +101,16 @@ function expect_ok(api_name, resource, err) {
 //XXX Consider just exiting without error after displaying notices
 
 tests_run++;
-if ( typeof fs.fcntl !== 'function' ) {
-  console.log('fs.fcntl API is missing');
+if ( typeof fsExt.fcntl !== 'function' ) {
+  console.log('fsExt.fcntl API is missing');
 }
 else {
   tests_ok++;
 }
 
 tests_run++;
-if ( typeof fs.fcntlSync !== 'function' ) {
-  console.log('fs.fcntlSync API is missing');
+if ( typeof fsExt.fcntlSync !== 'function' ) {
+  console.log('fsExt.fcntlSync API is missing');
 }
 else {
   tests_ok++;
@@ -143,22 +144,20 @@ if ( tests_run !== tests_ok ) {
 
 // Test that constants are published -  -  -  -  -  -  -  -
 
-var fs_binding = require('../build/Release/fs-ext');
-
 var constant_names = [ 'F_SETFD',  'F_GETFD',  'FD_CLOEXEC' ];
 
 constant_names.forEach(function(name){
 
-  if (debug_me) console.log('  %s    %j    %j', name, fs_binding[name], typeof fs_binding[name]);
+  if (debug_me) console.log('  %s    %j    %j', name, fsExt.constants[name], typeof fsExt.constants[name]);
 
   tests_run++;
-  if ( fs_binding[name] !== undefined  &&
-     typeof fs_binding[name] === 'number' ) {
+  if ( fsExt.constants[name] !== undefined  &&
+     typeof fsExt.constants[name] === 'number' ) {
     tests_ok++;
   }
   else {
     console.log('FAILURE: %s is not defined correctly', name);
-    console.log('  %s    %j    %j', name, fs_binding[name], typeof fs_binding[name]);
+    console.log('  %s    %j    %j', name, fsExt.constants[name], typeof fsExt.constants[name]);
   }
 });
 
@@ -169,7 +168,7 @@ constant_names.forEach(function(name){
 
 tests_run++;
 try {
-  err = fs.fcntlSync(undefined, 0);
+  err = fsExt.fcntlSync(undefined, 0);
 }
 catch (e) {
   err = e;
@@ -188,7 +187,7 @@ else if (debug_me) {
 
 tests_run++;
 try {
-  err = fs.fcntlSync('foo', 0);
+  err = fsExt.fcntlSync('foo', 0);
 }
 catch (e) {
   err = e;
@@ -207,7 +206,7 @@ else if (debug_me) {
 
 tests_run++;
 try {
-  err = fs.fcntlSync(-9, 0);
+  err = fsExt.fcntlSync(-9, 0);
 }
 catch (e) {
   err = e;
@@ -219,7 +218,7 @@ expect_errno('fcntlSync', -9, err, 'EBADF');
 
 tests_run++;
 try {
-  err = fs.fcntlSync(98765, 0);
+  err = fsExt.fcntlSync(98765, 0);
 }
 catch (e) {
   err = e;
@@ -232,7 +231,7 @@ expect_errno('fcntlSync', 98765, err, 'EBADF');
 
 tests_run++;
 try {
-  err = fs.fcntlSync(file_fd, 'foo');
+  err = fsExt.fcntlSync(file_fd, 'foo');
 }
 catch (e) {
   err = e;
@@ -253,7 +252,7 @@ else if (debug_me) {
 tests_run++;
 try {
   err = null;
-  fs.fcntlSync(file_fd, 'getfd');
+  fsExt.fcntlSync(file_fd, 'getfd');
 }
 catch (e) {
   err = e;
@@ -266,18 +265,18 @@ expect_ok('fcntlSync', file_fd, err);
 tests_run++;
 try {
   err = null;
-  var flags = fs.fcntlSync(file_fd, 'getfd');
+  var flags = fsExt.fcntlSync(file_fd, 'getfd');
   console.log("initial flags:" + (flags));
 
-  fs.fcntlSync(file_fd, 'setfd', flags | fs_binding.FD_CLOEXEC);
-  flags = fs.fcntlSync(file_fd, 'getfd');
-  if ((flags & fs_binding.FD_CLOEXEC) !== fs_binding.FD_CLOEXEC) {
+  fsExt.fcntlSync(file_fd, 'setfd', flags | fsExt.constants.FD_CLOEXEC);
+  flags = fsExt.fcntlSync(file_fd, 'getfd');
+  if ((flags & fsExt.constants.FD_CLOEXEC) !== fsExt.constants.FD_CLOEXEC) {
     throw new Error("Expected FD_CLOEXEC to be set: " + flags);
   }
 
-  fs.fcntlSync(file_fd, 'setfd', flags & (~fs_binding.FD_CLOEXEC));
-  flags = fs.fcntlSync(file_fd, 'getfd');
-  if ((flags & fs_binding.FD_CLOEXEC) === fs_binding.FD_CLOEXEC) {
+  fsExt.fcntlSync(file_fd, 'setfd', flags & (~fsExt.constants.FD_CLOEXEC));
+  flags = fsExt.fcntlSync(file_fd, 'getfd');
+  if ((flags & fsExt.constants.FD_CLOEXEC) === fsExt.constants.FD_CLOEXEC) {
     throw new Error("Expected FD_CLOEXEC to be cleared");
   }
 }
@@ -291,31 +290,31 @@ expect_ok('fcntlSync', file_fd, err);
 // SEEK_SET to 0
 
 tests_run++;
-fs.fcntl(file_fd, 'getfd', function(err, flags) {
+fsExt.fcntl(file_fd, 'getfd', function(err, flags) {
   expect_ok('fcntl', file_fd, err);
 
   tests_run++;
-  fs.fcntl(file_fd, 'setfd', flags | fs_binding.FD_CLOEXEC, function(err) {
+  fsExt.fcntl(file_fd, 'setfd', flags | fsExt.constants.FD_CLOEXEC, function(err) {
     expect_ok('fcntl', file_fd, err);
 
     tests_run++;
-    fs.fcntl(file_fd, 'getfd', function(err, flags) {
+    fsExt.fcntl(file_fd, 'getfd', function(err, flags) {
       expect_ok('fcntl', file_fd, err);
 
-      if ((flags & fs_binding.FD_CLOEXEC) !== fs_binding.FD_CLOEXEC) {
+      if ((flags & fsExt.constants.FD_CLOEXEC) !== fsExt.constants.FD_CLOEXEC) {
         tests_run++;
         expect_ok('fcntl', file_fd, new Error("did not set cloexec"));
       }
 
       tests_run++;
-      fs.fcntl(file_fd, 'setfd', flags & (~fs_binding.FD_CLOEXEC), function(err, flags) {
+      fsExt.fcntl(file_fd, 'setfd', flags & (~fsExt.constants.FD_CLOEXEC), function(err, flags) {
         expect_ok('fcntl', file_fd, err);
 
         tests_run++;
-        fs.fcntl(file_fd, 'getfd', function(err, flags) {
+        fsExt.fcntl(file_fd, 'getfd', function(err, flags) {
           expect_ok('fcntl', file_fd, err);
 
-          if ((flags & fs_binding.FD_CLOEXEC) === fs_binding.FD_CLOEXEC) {
+          if ((flags & fsExt.constants.FD_CLOEXEC) === fsExt.constants.FD_CLOEXEC) {
             tests_run++;
             expect_ok('fcntl', file_fd, new Error("did not clear cloexec"));
           }
@@ -327,7 +326,7 @@ fs.fcntl(file_fd, 'getfd', function(err, flags) {
           tests_run++;
 
           try {
-            fs.fcntl(file_fd, 'foo', function(err) {
+            fsExt.fcntl(file_fd, 'foo', function(err) {
               console.log('  unexpected callback from fcntl() with bad argument');
             });
             err = undefined;

--- a/tests/test-fs-flock.js
+++ b/tests/test-fs-flock.js
@@ -2,13 +2,13 @@
 
 // Test these APIs as published in extension module 'fs-ext'
 //
-// fs.flock(fd, flags, [callback])
+// fsExt.flock(fd, flags, [callback])
 //
 // Asynchronous flock(2).  No arguments other than a possible error are
 // passed to the callback.  Flags can be 'sh', 'ex', 'shnb', 'exnb', 'un'
 // and correspond to the various LOCK_SH, LOCK_EX, LOCK_SH|LOCK_NB, etc.
 //
-// fs.flockSync(fd, flags)
+// fsExt.flockSync(fd, flags)
 //
 // Synchronous flock(2). Throws an exception on error.
 
@@ -26,7 +26,8 @@
 var assert = require('assert'),
   path   = require('path'),
   util   = require('util'),
-  fs     = require('../fs-ext'),
+  fs     = require('fs'),
+  fsExt  = require('../fs-ext'),
   os     = require('os');
 
 var tests_ok  = 0,
@@ -118,16 +119,16 @@ function expect_ok(api_name, resource, err) {
 //XXX Consider just exiting without error after displaying notices
 
 tests_run++;
-if ( typeof fs.flock !== 'function' ) {
-  console.log('fs.flock API is missing');
+if ( typeof fsExt.flock !== 'function' ) {
+  console.log('fsExt.flock API is missing');
 }
 else {
   tests_ok++;
 }
 
 tests_run++;
-if ( typeof fs.flockSync !== 'function' ) {
-  console.log('fs.flockSync API is missing');
+if ( typeof fsExt.flockSync !== 'function' ) {
+  console.log('fsExt.flockSync API is missing');
 }
 else {
   tests_ok++;
@@ -161,22 +162,20 @@ if ( tests_run !== tests_ok ) {
 
 // Test that constants are published -  -  -  -  -  -  -  -
 
-var fs_binding = require('../build/Release/fs-ext');
-
 var constant_names = [ 'LOCK_EX',  'LOCK_NB',  'LOCK_SH',  'LOCK_UN' ];
 
 constant_names.forEach(function(name){
 
-  if (debug_me) console.log('  %s    %j    %j', name, fs_binding[name], typeof fs_binding[name]);
+  if (debug_me) console.log('  %s    %j    %j', name, fsExt.constants[name], typeof fsExt.constants[name]);
 
   tests_run++;
-  if ( fs_binding[name] !== undefined  &&
-     typeof fs_binding[name] === 'number' ) {
+  if ( fsExt.constants[name] !== undefined  &&
+     typeof fsExt.constants[name] === 'number' ) {
     tests_ok++;
   }
   else {
     console.log('FAILURE: %s is not defined correctly', name);
-    console.log('  %s    %j    %j', name, fs_binding[name], typeof fs_binding[name]);
+    console.log('  %s    %j    %j', name, fsExt.constants[name], typeof fsExt.constants[name]);
   }
 });
 
@@ -187,7 +186,7 @@ constant_names.forEach(function(name){
 
 tests_run++;
 try {
-  err = fs.flockSync(undefined, 'un');
+  err = fsExt.flockSync(undefined, 'un');
 }
 catch (e) {
   err = e;
@@ -206,7 +205,7 @@ else if (debug_me) {
 
 tests_run++;
 try {
-  err = fs.flockSync('foo', 'un');
+  err = fsExt.flockSync('foo', 'un');
 }
 catch (e) {
   err = e;
@@ -225,7 +224,7 @@ else if (debug_me) {
 
 tests_run++;
 try {
-  err = fs.flockSync(-9, 'un');
+  err = fsExt.flockSync(-9, 'un');
 }
 catch (e) {
   err = e;
@@ -237,7 +236,7 @@ expect_errno('flockSync', -9, err, 'EBADF');
 
 tests_run++;
 try {
-  err = fs.flockSync(98765, 'un');
+  err = fsExt.flockSync(98765, 'un');
 }
 catch (e) {
   err = e;
@@ -251,7 +250,7 @@ expect_errno('flockSync', 98765, err, 'EBADF');
 
 tests_run++;
 try {
-  err = fs.flockSync(file_fd, 'foo');
+  err = fsExt.flockSync(file_fd, 'foo');
 }
 catch (e) {
   err = e;
@@ -275,7 +274,7 @@ else if (debug_me) {
 
 tests_run++;
 try {
-  err = fs.flockSync(file_fd, 'un');
+  err = fsExt.flockSync(file_fd, 'un');
 }
 catch (e) {
   err = e;
@@ -287,7 +286,7 @@ expect_ok('flockSync', file_fd, err);
 
 tests_run++;
 try {
-  err = fs.flockSync(file_fd, 'sh');
+  err = fsExt.flockSync(file_fd, 'sh');
 }
 catch (e) {
   err = e;
@@ -296,7 +295,7 @@ expect_ok('flockSync', file_fd, err);
 
 tests_run++;
 try {
-  err = fs.flockSync(file_fd, 'un');
+  err = fsExt.flockSync(file_fd, 'un');
 }
 catch (e) {
   err = e;
@@ -308,7 +307,7 @@ expect_ok('flockSync', file_fd, err);
 
 tests_run++;
 try {
-  err = fs.flockSync(file_fd, 'ex');
+  err = fsExt.flockSync(file_fd, 'ex');
 }
 catch (e) {
   err = e;
@@ -317,7 +316,7 @@ expect_ok('flockSync', file_fd, err);
 
 tests_run++;
 try {
-  err = fs.flockSync(file_fd, 'un');
+  err = fsExt.flockSync(file_fd, 'un');
 }
 catch (e) {
   err = e;
@@ -329,7 +328,7 @@ expect_ok('flockSync', file_fd, err);
 
 tests_run++;
 try {
-  err = fs.flockSync(file_fd, 'shnb');
+  err = fsExt.flockSync(file_fd, 'shnb');
 }
 catch (e) {
   err = e;
@@ -338,7 +337,7 @@ expect_ok('flockSync', file_fd, err);
 
 tests_run++;
 try {
-  err = fs.flockSync(file_fd, 'un');
+  err = fsExt.flockSync(file_fd, 'un');
 }
 catch (e) {
   err = e;
@@ -350,7 +349,7 @@ expect_ok('flockSync', file_fd, err);
 
 tests_run++;
 try {
-  err = fs.flockSync(file_fd, 'exnb');
+  err = fsExt.flockSync(file_fd, 'exnb');
 }
 catch (e) {
   err = e;
@@ -359,7 +358,7 @@ expect_ok('flockSync', file_fd, err);
 
 tests_run++;
 try {
-  err = fs.flockSync(file_fd, 'un');
+  err = fsExt.flockSync(file_fd, 'un');
 }
 catch (e) {
   err = e;
@@ -379,7 +378,7 @@ expect_ok('flockSync', file_fd, err);
 
 tests_run++;
 tests_run++;
-fs.flock(file_fd, 'sh', function(err, extra) {
+fsExt.flock(file_fd, 'sh', function(err, extra) {
   expect_ok('flock', file_fd, err);
 
   // After a change to returning arguments to async callback routines,
@@ -392,7 +391,7 @@ fs.flock(file_fd, 'sh', function(err, extra) {
   }
 
   tests_run++;
-  fs.flock(file_fd, 'exnb', function(err) {
+  fsExt.flock(file_fd, 'exnb', function(err) {
     if (process.platform === 'win32') {
       // Windows doesn't support lock upgrades
       expect_errno('flock', 10035, err, 'EWOULDBLOCK');
@@ -402,7 +401,7 @@ fs.flock(file_fd, 'sh', function(err, extra) {
     }
 
     tests_run++;
-    fs.flock(file_fd, 'un', function(err) {
+    fsExt.flock(file_fd, 'un', function(err) {
       expect_ok('flock', file_fd, err);
 
       // Test invalid calls: flock  -  -  -  -  -  -  -  -  -
@@ -411,7 +410,7 @@ fs.flock(file_fd, 'sh', function(err, extra) {
       tests_run++;
 
       try {
-        fs.flock(file_fd, 'foo', function(err) {
+        fsExt.flock(file_fd, 'foo', function(err) {
           console.log('  unexpected callback from flock() with bad argument');
         });
         err = undefined;

--- a/tests/test-fs-seek.js
+++ b/tests/test-fs-seek.js
@@ -2,7 +2,7 @@
 
 // Test these APIs as published in extension module 'fs-ext'
 
-//    fs.seek(fd, offset, whence, [callback])
+//    fsExt.seek(fd, offset, whence, [callback])
 //
 //  Asynchronous lseek(2).
 //
@@ -13,7 +13,7 @@
 //  bytes (can be negative), or 2 (SEEK_END) to set to the end of the file
 //  plus offset bytes (usually negative or zero to seek to the end of the file).
 //
-//    fs.seekSync(fd, offset, whence)
+//    fsExt.seekSync(fd, offset, whence)
 //
 //  Synchronous lseek(2). Throws an exception on error.  Returns current
 //  file position.
@@ -47,7 +47,8 @@
 var assert = require('assert'),
   path   = require('path'),
   util   = require('util'),
-  fs     = require('../fs-ext'),
+  fs     = require('fs'),
+  fsExt  = require('../fs-ext'),
   os     = require('os');
 
 var tests_ok  = 0,
@@ -220,16 +221,16 @@ function expect_error(api_name, err, value_seen, expected_error) {
 //XXX Consider just exiting without error after displaying notices
 
 tests_run++;
-if ( typeof fs.seek !== 'function' ) {
-  console.log('fs.seek API is missing');
+if ( typeof fsExt.seek !== 'function' ) {
+  console.log('fsExt.seek API is missing');
 }
 else {
   tests_ok++;
 }
 
 tests_run++;
-if ( typeof fs.seekSync !== 'function' ) {
-  console.log('fs.seekSync API is missing');
+if ( typeof fsExt.seekSync !== 'function' ) {
+  console.log('fsExt.seekSync API is missing');
 }
 else {
   tests_ok++;
@@ -263,22 +264,20 @@ if ( tests_run !== tests_ok ) {
 
 // Test that constants are published -  -  -  -  -  -  -  -
 
-var fs_binding = require('../build/Release/fs-ext');
-
 var constant_names = [ 'SEEK_SET',  'SEEK_CUR',  'SEEK_END' ];
 
 constant_names.forEach(function(name){
 
-  if (debug_me) console.log('  %s    %j    %j', name, fs_binding[name], typeof fs_binding[name]);
+  if (debug_me) console.log('  %s    %j    %j', name, fsExt.constants[name], typeof fsExt.constants[name]);
 
   tests_run++;
-  if ( fs_binding[name] !== undefined  &&
-     typeof fs_binding[name] === 'number' ) {
+  if ( fsExt.constants[name] !== undefined  &&
+     typeof fsExt.constants[name] === 'number' ) {
     tests_ok++;
   }
   else {
     console.log('FAILURE: %s is not defined correctly', name);
-    console.log('  %s    %j    %j', name, fs_binding[name], typeof fs_binding[name]);
+    console.log('  %s    %j    %j', name, fsExt.constants[name], typeof fsExt.constants[name]);
   }
 });
 
@@ -291,7 +290,7 @@ constant_names.forEach(function(name){
 tests_run++;
 result = err = undefined;
 try {
-  result = fs.seekSync(undefined, 0, 0);
+  result = fsExt.seekSync(undefined, 0, 0);
 }
 catch (e) {
   err = e;
@@ -304,7 +303,7 @@ expect_error('seekSync', err, result, 'Bad argument');
 tests_run++;
 result = err = undefined;
 try {
-  result = fs.seekSync('foo', 0, 0);
+  result = fsExt.seekSync('foo', 0, 0);
 }
 catch (e) {
   err = e;
@@ -317,7 +316,7 @@ expect_error('seekSync', err, result, 'Bad argument');
 tests_run++;
 result = err = undefined;
 try {
-  result = fs.seekSync(-9, 0, 0);
+  result = fsExt.seekSync(-9, 0, 0);
 }
 catch (e) {
   err = e;
@@ -330,7 +329,7 @@ expect_errno('seekSync', err, result, 'EBADF');
 tests_run++;
 result = err = undefined;
 try {
-  result = fs.seekSync(98765, 0, 0);
+  result = fsExt.seekSync(98765, 0, 0);
 }
 catch (e) {
   err = e;
@@ -343,7 +342,7 @@ expect_errno('seekSync', err, result, 'EBADF');
 tests_run++;
 result = err = undefined;
 try {
-  result = fs.seekSync(file_fd, 0, 98765);
+  result = fsExt.seekSync(file_fd, 0, 98765);
 }
 catch (e) {
   err = e;
@@ -354,7 +353,7 @@ expect_errno('seekSync', err, result, 'EINVAL');
 tests_run++;
 result = err = undefined;
 try {
-  result = fs.seekSync(file_fd, 0, -99);
+  result = fsExt.seekSync(file_fd, 0, -99);
 }
 catch (e) {
   err = e;
@@ -367,7 +366,7 @@ expect_errno('seekSync', err, result, 'EINVAL');
 tests_run++;
 result = err = undefined;
 try {
-  result = fs.seekSync(file_fd, -98765, 0);
+  result = fsExt.seekSync(file_fd, -98765, 0);
 }
 catch (e) {
   err = e;
@@ -380,7 +379,7 @@ expect_errno('seekSync', err, result, 'EINVAL');
 tests_run++;
 result = err = undefined;
 try {
-  result = fs.seekSync(file_fd, 4.0001, 0);
+  result = fsExt.seekSync(file_fd, 4.0001, 0);
 }
 catch (e) {
   err = e;
@@ -394,7 +393,7 @@ expect_error('seekSync', err, result, 'Not an integer');
 tests_run++;
 result = err = undefined;
 try {
-  result = fs.seekSync(file_fd, 98765, 0);
+  result = fsExt.seekSync(file_fd, 98765, 0);
 }
 catch (e) {
   err = e;
@@ -408,7 +407,7 @@ tests_run++;
 result = err = undefined;
 offset_big = 2 * 1024 * 1024 * 1024 - 1;
 try {
-  result = fs.seekSync(file_fd, offset_big, 0);
+  result = fsExt.seekSync(file_fd, offset_big, 0);
 }
 catch (e) {
   err = e;
@@ -420,7 +419,7 @@ tests_run++;
 result = err = undefined;
 offset_big = 2 * 1024 * 1024 * 1024;
 try {
-  result = fs.seekSync(file_fd, offset_big, 0);
+  result = fsExt.seekSync(file_fd, offset_big, 0);
 }
 catch (e) {
   err = e;
@@ -432,7 +431,7 @@ tests_run++;
 result = err = undefined;
 offset_big = 42 * 1024 * 1024 * 1024;
 try {
-  result = fs.seekSync(file_fd, offset_big, 0);
+  result = fsExt.seekSync(file_fd, offset_big, 0);
 }
 catch (e) {
   err = e;
@@ -445,7 +444,7 @@ result = err = undefined;
 offset_big = 8 * 1024 * 1024 * 1024 * 1024 - 1;
 // Linux is limited to 43 bits for file position values?
 try {
-  result = fs.seekSync(file_fd, offset_big, 0);
+  result = fsExt.seekSync(file_fd, offset_big, 0);
 }
 catch (e) {
   err = e;
@@ -460,7 +459,7 @@ expect_value('seekSync', err, result, offset_big);
 // // Linux is limited to 43 bits for file position values?
 // //console.log('    offset_big   %s    %s', offset_big.toString(), offset_big.toString(16) );
 // try {
-//   result = fs.seekSync(file_fd, offset_big, 0);
+//   result = fsExt.seekSync(file_fd, offset_big, 0);
 //   //console.log('    result       %s    %s', result.toString(), result.toString(16) );
 // } catch (e) {
 //   err = e;
@@ -476,7 +475,7 @@ expect_value('seekSync', err, result, offset_big);
 tests_run++;
 result = err = undefined;
 try {
-  result = fs.seekSync(file_fd, 0, 0);
+  result = fsExt.seekSync(file_fd, 0, 0);
 }
 catch (e) {
   err = e;
@@ -489,7 +488,7 @@ expect_value('seekSync', err, result, 0);
 tests_run++;
 result = err = undefined;
 try {
-  result = fs.seekSync(file_fd, 0, 1);
+  result = fsExt.seekSync(file_fd, 0, 1);
 }
 catch (e) {
   err = e;
@@ -502,7 +501,7 @@ expect_value('seekSync', err, result, 0);
 tests_run++;
 result = err = undefined;
 try {
-  result = fs.seekSync(file_fd, 0, 2);
+  result = fsExt.seekSync(file_fd, 0, 2);
 }
 catch (e) {
   err = e;
@@ -515,7 +514,7 @@ expect_value('seekSync', err, result, 0);
 tests_run++;
 result = err = undefined;
 try {
-  result = fs.seekSync(file_fd, 0, fs_binding.SEEK_SET);
+  result = fsExt.seekSync(file_fd, 0, fsExt.constants.SEEK_SET);
 }
 catch (e) {
   err = e;
@@ -528,7 +527,7 @@ expect_value('seekSync', err, result, 0);
 tests_run++;
 result = err = undefined;
 try {
-  result = fs.seekSync(file_fd, 0, fs_binding.SEEK_CUR);
+  result = fsExt.seekSync(file_fd, 0, fsExt.constants.SEEK_CUR);
 }
 catch (e) {
   err = e;
@@ -541,7 +540,7 @@ expect_value('seekSync', err, result, 0);
 tests_run++;
 result = err = undefined;
 try {
-  result = fs.seekSync(file_fd, 0, fs_binding.SEEK_END);
+  result = fsExt.seekSync(file_fd, 0, fsExt.constants.SEEK_END);
 }
 catch (e) {
   err = e;
@@ -556,28 +555,28 @@ expect_value('seekSync', err, result, 0);
 // SEEK_SET to 0
 
 tests_run++;
-fs.seek(file_fd, 0, 0, function(err, result) {
+fsExt.seek(file_fd, 0, 0, function(err, result) {
   expect_value('seek', err, result, 0);
 
   tests_run++;
-  fs.seek(file_fd, 0, 1, function(err, result) {
+  fsExt.seek(file_fd, 0, 1, function(err, result) {
     expect_value('seek', err, result, 0);
 
     tests_run++;
-    fs.seek(file_fd, 0, 2, function(err, result) {
+    fsExt.seek(file_fd, 0, 2, function(err, result) {
       expect_value('seek', err, result, 0);
 
       // Test invalid calls: seek  -  -  -  -  -  -  -  -  -
 
       // offset value is negative
       tests_run++;
-      fs.seek(file_fd, -98765, 0, function(err, result) {
+      fsExt.seek(file_fd, -98765, 0, function(err, result) {
         expect_errno('seek', err, result, 'EINVAL');
 
         // offset value is quite large (over 32 bits)
         tests_run++;
         offset_big = 42 * 1024 * 1024 * 1024;
-        fs.seek(file_fd, offset_big, 0, function(err, result) {
+        fsExt.seek(file_fd, offset_big, 0, function(err, result) {
           expect_value('seek', err, result, offset_big);
         });
       });


### PR DESCRIPTION
This PR removes override of `fs` and `constants` core Node.js modules. Instead all functions and constants should be imported explicitly:

```js
const {flock, constants} = require('fs-ext');
// or
const fsExt = require('fs-ext');
// fsExt.flock
// fsExt.constants
``` 

In C++ binding all constants are placed to `constants` object instead of `target` object, e.g. on my machine:

```
> require('./build/Release/fs-ext')
{ constants:
   { SEEK_SET: 0,
     SEEK_CUR: 1,
     SEEK_END: 2,
     LOCK_SH: 1,
     LOCK_EX: 2,
     LOCK_NB: 4,
     LOCK_UN: 8,
     F_GETFD: 1,
     F_SETFD: 2,
     FD_CLOEXEC: 1,
     F_RDLCK: 0,
     F_WRLCK: 1,
     F_UNLCK: 2,
     F_SETLK: 6,
     F_GETLK: 5,
     F_SETLKW: 7 },
  seek: [Function],
  fcntl: [Function],
  flock: [Function],
  statVFS: [Function] }
```

This helps to export constants on JavaScript side without pattern matching:

https://github.com/baudehlo/node-fs-ext/blob/42b87130b3f01e78d5b5522f94ab6d955c57746d/fs-ext.js#L142

**Other changes**

* Use `fsExt` module in tests instead `binding` directly.
* Update examples in `README.md` to use modern JavaScript (destructuring, arrow functions), because minimum supported version is `Node.js 8`.

Please note that it's breaking change. Therefore, major version should be updated.

Fixes https://github.com/baudehlo/node-fs-ext/issues/89
Fixes https://github.com/baudehlo/node-fs-ext/issues/81
