### PR TITLE
Fix compatibility with webpack

### DIFF
--- a/fs-ext.js
+++ b/fs-ext.js
@@ -19,7 +19,7 @@
 
 "use strict";
 
-var binding = require('./build/Release/fs-ext');
+var binding = require('./build/Release/fs-ext.node');
 
 // Used by flock
 function stringToFlockFlags(flag) {


### PR DESCRIPTION
Leaving out the `.node` extension leaves Webpack confused on which loader to use. Adding it back allows Webpack to recognize this module correctly as a native one.